### PR TITLE
Workaround to make FASTRTPS test work with two processes

### DIFF
--- a/performance_test/src/communication_abstractions/fast_rtps_communicator.hpp
+++ b/performance_test/src/communication_abstractions/fast_rtps_communicator.hpp
@@ -162,8 +162,8 @@ public:
 
       eprosima::fastrtps::PublisherAttributes wparam;
       wparam.topic.topicKind = eprosima::fastrtps::rtps::TopicKind_t::NO_KEY;
-      wparam.topic.topicDataType = m_topic_type->getName() + m_ec.pub_topic_postfix();
-      wparam.topic.topicName = Topic::topic_name();
+      wparam.topic.topicDataType = m_topic_type->getName();
+      wparam.topic.topicName = Topic::topic_name() + m_ec.pub_topic_postfix();
       wparam.topic.historyQos.kind = qos.history_kind();
       wparam.topic.historyQos.depth = qos.history_depth();
       wparam.topic.resourceLimitsQos.max_samples = qos.resource_limits_samples();
@@ -198,8 +198,8 @@ public:
 
       eprosima::fastrtps::SubscriberAttributes rparam;
       rparam.topic.topicKind = eprosima::fastrtps::rtps::TopicKind_t::NO_KEY;
-      rparam.topic.topicDataType = m_topic_type->getName() + m_ec.sub_topic_postfix();
-      rparam.topic.topicName = Topic::topic_name();
+      rparam.topic.topicDataType = m_topic_type->getName();
+      rparam.topic.topicName = Topic::topic_name() + m_ec.sub_topic_postfix();
       rparam.topic.historyQos.kind = qos.history_kind();
       rparam.topic.historyQos.depth = qos.history_depth();
       rparam.topic.resourceLimitsQos.max_samples = qos.resource_limits_samples();

--- a/performance_test/src/communication_abstractions/fast_rtps_communicator.hpp
+++ b/performance_test/src/communication_abstractions/fast_rtps_communicator.hpp
@@ -210,7 +210,7 @@ public:
     }
 
     if (!m_ec.no_waitset()) {
-      m_subscriber->waitForUnreadMessage();
+      m_subscriber->wait_for_unread_samples({3, 0});
     }
     lock();
     while (m_subscriber->takeNextData(static_cast<void *>(&m_data), &m_info)) {


### PR DESCRIPTION
Changes suggested by @EduPonz 

The issue with the `roundtrip_mode` is that the mode postfixes are not appended correctly, meaning that the postfixes are appended to the topicDataType instead of the the topicName.

However, there is another problem that may arise sometimes when running this mode; that is that the test does not close on `max_time` reached. This is because `FastRTPSCommunicator::update_subscription()` calls to `m_subscriber->waitForUnreadMessage()`, which blocks with a timeout of one day. There are two solutions for this:
 - Substitute waitForUnreadMessage() with the underlying SubscriberImpl::wait_for_unread_samples(const Duration_t& timeout), setting a shorter timeout.
 - Use the python script to kill the executable when the timeout is reached.

I choosed the first option, to kill the process in the launch file https://github.com/ros2/buildfarm_perf_tests/pull/26/commits/6aec12d38e6ea71a11b4b62e86272e1a1c618f9c

Signed-off-by: ahcorde <ahcorde@gmail.com>