### PR TITLE
Replace wait_for_unread_samples for waitForUnreadMessage

### DIFF
--- a/performance_test/src/communication_abstractions/fast_rtps_communicator.hpp
+++ b/performance_test/src/communication_abstractions/fast_rtps_communicator.hpp
@@ -210,7 +210,7 @@ public:
     }
 
     if (!m_ec.no_waitset()) {
-      m_subscriber->wait_for_unread_samples({3, 0});
+      m_subscriber->waitForUnreadMessage();
     }
     lock();
     while (m_subscriber->takeNextData(static_cast<void *>(&m_data), &m_info)) {


### PR DESCRIPTION
This method call is not defined in the fastrtps version for in dashing. Using an available method

Signed-off-by: ahcorde <ahcorde@gmail.com>