### PR TITLE
Fixed domainId fastrtps 2.x

### DIFF
--- a/performance_test/src/communication_abstractions/resource_manager.cpp
+++ b/performance_test/src/communication_abstractions/resource_manager.cpp
@@ -90,7 +90,7 @@ eprosima::fastrtps::Participant * ResourceManager::fastrtps_participant() const
   disc_config.m_simpleEDP.use_PublicationWriterANDSubscriptionReader = true;
   disc_config.leaseDuration = eprosima::fastrtps::c_TimeInfinite;
 #endif
-  PParam.rtps.builtin.domainId = m_ec.dds_domain_id();
+  PParam.domainId = m_ec.dds_domain_id();
   PParam.rtps.setName("performance_test_fastRTPS");
 
   if (!m_ec.use_single_participant()) {

--- a/performance_test/src/communication_abstractions/resource_manager.cpp
+++ b/performance_test/src/communication_abstractions/resource_manager.cpp
@@ -90,7 +90,12 @@ eprosima::fastrtps::Participant * ResourceManager::fastrtps_participant() const
   disc_config.m_simpleEDP.use_PublicationWriterANDSubscriptionReader = true;
   disc_config.leaseDuration = eprosima::fastrtps::c_TimeInfinite;
 #endif
+#if FASTRTPS_VERSION_MAJOR < 2
+  PParam.rtps.builtin.domainId = m_ec.dds_domain_id();
+#else
   PParam.domainId = m_ec.dds_domain_id();
+#endif
+
   PParam.rtps.setName("performance_test_fastRTPS");
 
   if (!m_ec.use_single_participant()) {


### PR DESCRIPTION
[Buildfarm is failing](http://build.ros2.org/view/Fci/job/Fci__nightly-performance_ubuntu_focal_amd64/35/console) due the recent changes in Foxy (moving to FastRTPS 2.x) this change is required.

Probably we will need to create a branch for `eloquent` -> `eloquent/run_on_buildfarm`

Signed-off-by: ahcorde <ahcorde@gmail.com>