### PR TITLE
Add larger message types

### DIFF
--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -134,6 +134,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
     "src/msg/Array1m.msg"
     "src/msg/Array2m.msg"
     "src/msg/Array4m.msg"
+    "src/msg/Array8m.msg"
 
     "src/msg/Struct16.msg"
     "src/msg/Struct256.msg"

--- a/performance_test/include/performance_test/for_each.hpp
+++ b/performance_test/include/performance_test/for_each.hpp
@@ -27,7 +27,7 @@ namespace performance_test
  * \param f functor to be applied over each element
  * \returns number of iterated elements
  */
-template<std::size_t I = 0, typename FuncT, typename... Tp>
+template<std::size_t I = 0, typename FuncT, typename ... Tp>
 typename std::enable_if<I == sizeof...(Tp), size_t>::type
 for_each(const std::tuple<Tp...> & t, FuncT f)
 {
@@ -36,7 +36,7 @@ for_each(const std::tuple<Tp...> & t, FuncT f)
   return I;
 }
 
-template<std::size_t I = 0, typename FuncT, typename... Tp>
+template<std::size_t I = 0, typename FuncT, typename ... Tp>
 typename std::enable_if<I != sizeof...(Tp), size_t>::type
 for_each(const std::tuple<Tp...> & t, FuncT f)
 {
@@ -44,6 +44,6 @@ for_each(const std::tuple<Tp...> & t, FuncT f)
   return for_each<I + 1, FuncT, Tp...>(t, f);
 }
 
-}  // performance_test
+}  // namespace performance_test
 
 #endif  // PERFORMANCE_TEST__FOR_EACH_HPP_

--- a/performance_test/include/performance_test/for_each.hpp
+++ b/performance_test/include/performance_test/for_each.hpp
@@ -1,0 +1,48 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PERFORMANCE_TEST__FOR_EACH_HPP_
+#define PERFORMANCE_TEST__FOR_EACH_HPP_
+
+#include <tuple>
+#include <utility> 
+
+namespace performance_test
+{
+
+/// Iterates over std::tuple types
+/**
+ * \param f functor to be applied over each element
+ * \returns number of iterated elements
+ */
+template<std::size_t I = 0, typename FuncT, typename... Tp>
+typename std::enable_if<I == sizeof...(Tp), size_t>::type
+for_each(const std::tuple<Tp...> & t, FuncT f)
+{
+  (void)t;
+  (void)f;
+  return I;
+}
+
+template<std::size_t I = 0, typename FuncT, typename... Tp>
+typename std::enable_if<I != sizeof...(Tp), size_t>::type
+for_each(const std::tuple<Tp...> & t, FuncT f)
+{
+  f(std::get<I>(t));
+  return for_each<I + 1, FuncT, Tp...>(t, f);
+}
+
+}  // performance_test
+
+#endif  // PERFORMANCE_TEST__FOR_EACH_HPP_

--- a/performance_test/include/performance_test/for_each.hpp
+++ b/performance_test/include/performance_test/for_each.hpp
@@ -16,13 +16,14 @@
 #define PERFORMANCE_TEST__FOR_EACH_HPP_
 
 #include <tuple>
-#include <utility> 
+#include <utility>
 
 namespace performance_test
 {
 
 /// Iterates over std::tuple types
 /**
+ * \param t tuple to be iterated
  * \param f functor to be applied over each element
  * \returns number of iterated elements
  */

--- a/performance_test/src/data_running/data_runner_factory.cpp
+++ b/performance_test/src/data_running/data_runner_factory.cpp
@@ -14,10 +14,10 @@
 
 #include "data_runner_factory.hpp"
 
+#include <performance_test/for_each.hpp>
+
 #include <string>
 #include <memory>
-
-#include <performance_test/for_each.hpp>
 
 #ifdef PERFORMANCE_TEST_POLLING_SUBSCRIPTION_ENABLED
   #include "../communication_abstractions/ros2_waitset_communicator.hpp"

--- a/performance_test/src/data_running/data_runner_factory.cpp
+++ b/performance_test/src/data_running/data_runner_factory.cpp
@@ -14,11 +14,10 @@
 
 #include "data_runner_factory.hpp"
 
-#include <boost/mpl/for_each.hpp>
-
 #include <string>
 #include <memory>
 
+#include <performance_test/for_each.hpp>
 
 #ifdef PERFORMANCE_TEST_POLLING_SUBSCRIPTION_ENABLED
   #include "../communication_abstractions/ros2_waitset_communicator.hpp"
@@ -52,8 +51,9 @@ std::shared_ptr<DataRunnerBase> DataRunnerFactory::get(
   const RunType run_type)
 {
   std::shared_ptr<DataRunnerBase> ptr;
-  boost::mpl::for_each<topics::TopicTypeList>([&ptr, requested_topic_name, com_mean,
-    run_type](auto topic) {
+  performance_test::for_each(
+    topics::TopicTypeList(),
+    [&ptr, requested_topic_name, com_mean, run_type](auto topic) {
       using T = decltype(topic);
       if (T::topic_name() == requested_topic_name) {
         if (ptr) {

--- a/performance_test/src/data_running/data_runner_factory.cpp
+++ b/performance_test/src/data_running/data_runner_factory.cpp
@@ -53,8 +53,8 @@ std::shared_ptr<DataRunnerBase> DataRunnerFactory::get(
   std::shared_ptr<DataRunnerBase> ptr;
   performance_test::for_each(
     topics::TopicTypeList(),
-    [&ptr, requested_topic_name, com_mean, run_type](auto topic) {
-      using T = decltype(topic);
+    [&ptr, requested_topic_name, com_mean, run_type](const auto & topic) {
+      using T = std::remove_reference_t<std::remove_cv_t<decltype(topic)>>;
       if (T::topic_name() == requested_topic_name) {
         if (ptr) {
           throw std::runtime_error("It seems that two topics have the same name");

--- a/performance_test/src/data_running/data_runner_factory.cpp
+++ b/performance_test/src/data_running/data_runner_factory.cpp
@@ -54,7 +54,7 @@ std::shared_ptr<DataRunnerBase> DataRunnerFactory::get(
   performance_test::for_each(
     topics::TopicTypeList(),
     [&ptr, requested_topic_name, com_mean, run_type](const auto & topic) {
-      using T = std::remove_reference_t<std::remove_cv_t<decltype(topic)>>;
+      using T = std::remove_cv_t<std::remove_reference_t<decltype(topic)>>;
       if (T::topic_name() == requested_topic_name) {
         if (ptr) {
           throw std::runtime_error("It seems that two topics have the same name");

--- a/performance_test/src/experiment_configuration/topics.hpp
+++ b/performance_test/src/experiment_configuration/topics.hpp
@@ -168,6 +168,7 @@
 
 #include <algorithm>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace performance_test

--- a/performance_test/src/experiment_configuration/topics.hpp
+++ b/performance_test/src/experiment_configuration/topics.hpp
@@ -19,9 +19,7 @@
 #ifndef EXPERIMENT_CONFIGURATION__TOPICS_HPP_
 #define EXPERIMENT_CONFIGURATION__TOPICS_HPP_
 
-
-#include <boost/mpl/list.hpp>
-#include <boost/mpl/for_each.hpp>
+#include <performance_test/for_each.hpp>
 
 // ROS2 2 types:
 #include <performance_test/msg/array1k.hpp>
@@ -32,6 +30,7 @@
 #include <performance_test/msg/array1m.hpp>
 #include <performance_test/msg/array2m.hpp>
 #include <performance_test/msg/array4m.hpp>
+#include <performance_test/msg/array8m.hpp>
 
 #include <performance_test/msg/struct16.hpp>
 #include <performance_test/msg/struct256.hpp>
@@ -42,6 +41,7 @@
 #include <performance_test/msg/point_cloud1m.hpp>
 #include <performance_test/msg/point_cloud2m.hpp>
 #include <performance_test/msg/point_cloud4m.hpp>
+#include <performance_test/msg/point_cloud8m.hpp>
 
 #include <performance_test/msg/range.hpp>
 #include <performance_test/msg/nav_sat_fix.hpp>
@@ -59,6 +59,7 @@
   #include <fast_rtps/Array1m_PubSubTypes.h>
   #include <fast_rtps/Array2m_PubSubTypes.h>
   #include <fast_rtps/Array4m_PubSubTypes.h>
+  #include <fast_rtps/Array8m_PubSubTypes.h>
 
   #include <fast_rtps/Struct16_PubSubTypes.h>
   #include <fast_rtps/Struct256_PubSubTypes.h>
@@ -69,6 +70,7 @@
   #include <fast_rtps/PointCloud1m_PubSubTypes.h>
   #include <fast_rtps/PointCloud2m_PubSubTypes.h>
   #include <fast_rtps/PointCloud4m_PubSubTypes.h>
+  #include <fast_rtps/PointCloud8m_PubSubTypes.h>
 
   #include <fast_rtps/Range_PubSubTypes.h>
   #include <fast_rtps/NavSatFix_PubSubTypes.h>
@@ -87,6 +89,7 @@
   #include <micro/Array1m_Support.h>
   #include <micro/Array2m_Support.h>
   #include <micro/Array4m_Support.h>
+  #include <micro/Array8m_Support.h>
 
   #include <micro/Struct16_Support.h>
   #include <micro/Struct256_Support.h>
@@ -97,6 +100,7 @@
   #include <micro/PointCloud1m_Support.h>
   #include <micro/PointCloud2m_Support.h>
   #include <micro/PointCloud4m_Support.h>
+  #include <micro/PointCloud8m_Support.h>
 
   #include <micro/Range_Support.h>
   #include <micro/NavSatFix_Support.h>
@@ -115,6 +119,7 @@
   #include <cyclonedds/Array1m_.h>
   #include <cyclonedds/Array2m_.h>
   #include <cyclonedds/Array4m_.h>
+  #include <cyclonedds/Array8m_.h>
 
   #include <cyclonedds/Struct16_.h>
   #include <cyclonedds/Struct256_.h>
@@ -125,6 +130,7 @@
   #include <cyclonedds/PointCloud1m_.h>
   #include <cyclonedds/PointCloud2m_.h>
   #include <cyclonedds/PointCloud4m_.h>
+  #include <cyclonedds/PointCloud8m_.h>
 
   #include <cyclonedds/Range_.h>
   #include <cyclonedds/NavSatFix_.h>
@@ -143,6 +149,8 @@
   #include <opendds/Array60k_TypeSupportImpl.h>
   #include <opendds/Array1m_TypeSupportImpl.h>
   #include <opendds/Array2m_TypeSupportImpl.h>
+  #include <opendds/Array4m_TypeSupportImpl.h>
+  #include <opendds/Array8m_TypeSupportImpl.h>
   #include <opendds/Struct16_TypeSupportImpl.h>
   #include <opendds/Struct256_TypeSupportImpl.h>
   #include <opendds/Struct4k_TypeSupportImpl.h>
@@ -151,6 +159,7 @@
   #include <opendds/PointCloud1m_TypeSupportImpl.h>
   #include <opendds/PointCloud2m_TypeSupportImpl.h>
   #include <opendds/PointCloud4m_TypeSupportImpl.h>
+  #include <opendds/PointCloud8m_TypeSupportImpl.h>
   #include <opendds/Range_TypeSupportImpl.h>
   #include <opendds/NavSatFix_TypeSupportImpl.h>
   #include <opendds/RadarDetection_TypeSupportImpl.h>
@@ -468,6 +477,84 @@ public:
   static std::string topic_name()
   {
     return std::string("Array2m");
+  }
+};
+
+class Array4m
+{
+public:
+  using RosType = performance_test::msg::Array4m;
+
+#ifdef PERFORMANCE_TEST_FASTRTPS_ENABLED
+  using EprosimaTopicType = performance_test_msgs::msg::dds_::Array4m_PubSubType;
+  using EprosimaType = typename EprosimaTopicType::type;
+#endif
+
+#ifdef PERFORMANCE_TEST_CONNEXTDDSMICRO_ENABLED
+  using ConnextDDSMicroType = performance_test_msg_dds__Array4m_;
+#endif
+
+#ifdef PERFORMANCE_TEST_CYCLONEDDS_ENABLED
+  using CycloneDDSType = performance_test_msgs_msg_dds__Array4m_;
+  static const dds_topic_descriptor_t * CycloneDDSDesc()
+  {
+    return &performance_test_msgs_msg_dds__Array4m__desc;
+  }
+#endif
+
+#ifdef PERFORMANCE_TEST_OPENDDS_ENABLED
+  using OpenDDSTopicType = performance_test_msgs::msg::dds_::Array4m_;
+  using OpenDDSDataWriterType = performance_test_msgs::msg::dds_::Array4m_DataWriter;
+  using OpenDDSDataReaderType = performance_test_msgs::msg::dds_::Array4m_DataReader;
+  using OpenDDSDataTypeSeq = performance_test_msgs::msg::dds_::Array4m_Seq;
+
+  static DDS::TypeSupport_ptr get_type_support()
+  {
+    return new performance_test_msgs::msg::dds_::Array4m_TypeSupportImpl();
+  }
+#endif
+  static std::string topic_name()
+  {
+    return std::string("Array4m");
+  }
+};
+
+class Array8m
+{
+public:
+  using RosType = performance_test::msg::Array8m;
+
+#ifdef PERFORMANCE_TEST_FASTRTPS_ENABLED
+  using EprosimaTopicType = performance_test_msgs::msg::dds_::Array8m_PubSubType;
+  using EprosimaType = typename EprosimaTopicType::type;
+#endif
+
+#ifdef PERFORMANCE_TEST_CONNEXTDDSMICRO_ENABLED
+  using ConnextDDSMicroType = performance_test_msg_dds__Array8m_;
+#endif
+
+#ifdef PERFORMANCE_TEST_CYCLONEDDS_ENABLED
+  using CycloneDDSType = performance_test_msgs_msg_dds__Array8m_;
+  static const dds_topic_descriptor_t * CycloneDDSDesc()
+  {
+    return &performance_test_msgs_msg_dds__Array8m__desc;
+  }
+#endif
+
+#ifdef PERFORMANCE_TEST_OPENDDS_ENABLED
+  using OpenDDSTopicType = performance_test_msgs::msg::dds_::Array8m_;
+  using OpenDDSDataWriterType = performance_test_msgs::msg::dds_::Array8m_DataWriter;
+  using OpenDDSDataReaderType = performance_test_msgs::msg::dds_::Array8m_DataReader;
+  using OpenDDSDataTypeSeq = performance_test_msgs::msg::dds_::Array8m_Seq;
+
+  static DDS::TypeSupport_ptr get_type_support()
+  {
+    return new performance_test_msgs::msg::dds_::Array8m_TypeSupportImpl();
+  }
+#endif
+  static std::string topic_name()
+  {
+    return std::string("Array8m");
   }
 };
 
@@ -814,6 +901,45 @@ public:
   }
 };
 
+class PointCloud8m
+{
+public:
+  using RosType = performance_test::msg::PointCloud8m;
+#ifdef PERFORMANCE_TEST_FASTRTPS_ENABLED
+  using EprosimaTopicType = performance_test_msgs::msg::dds_::PointCloud8m_PubSubType;
+  using EprosimaType = typename EprosimaTopicType::type;
+#endif
+
+#ifdef PERFORMANCE_TEST_CONNEXTDDSMICRO_ENABLED
+  using ConnextDDSMicroType = performance_test_msg_dds__PointCloud8m_;
+#endif
+
+#ifdef PERFORMANCE_TEST_CYCLONEDDS_ENABLED
+  using CycloneDDSType = performance_test_msgs_msg_dds__PointCloud8m_;
+  static const dds_topic_descriptor_t * CycloneDDSDesc()
+  {
+    return &performance_test_msgs_msg_dds__PointCloud8m__desc;
+  }
+#endif
+
+#ifdef PERFORMANCE_TEST_OPENDDS_ENABLED
+  using OpenDDSTopicType = performance_test_msgs::msg::dds_::PointCloud8m_;
+  using OpenDDSDataWriterType = performance_test_msgs::msg::dds_::PointCloud8m_DataWriter;
+  using OpenDDSDataReaderType = performance_test_msgs::msg::dds_::PointCloud8m_DataReader;
+  using OpenDDSDataTypeSeq = performance_test_msgs::msg::dds_::PointCloud8m_Seq;
+
+  static DDS::TypeSupport_ptr get_type_support()
+  {
+    return new performance_test_msgs::msg::dds_::PointCloud8m_TypeSupportImpl();
+  }
+#endif
+
+  static std::string topic_name()
+  {
+    return std::string("PointCloud8m");
+  }
+};
+
 class Range
 {
 public:
@@ -987,17 +1113,17 @@ public:
 };
 ///  \endcond
 
-using TopicTypeList = boost::mpl::list<Array1k, Array4k, Array16k, Array32k, Array60k, Array1m,
-    Array2m,
-    Struct16, Struct256, Struct4k, Struct32k, PointCloud512k, PointCloud1m, PointCloud2m,
-    PointCloud4m,
+using TopicTypeList = std::tuple<Array1k, Array4k, Array16k, Array32k, Array60k, Array1m,
+    Array2m, Array4m, Array8m,
+    Struct16, Struct256, Struct4k, Struct32k,
+    PointCloud512k, PointCloud1m, PointCloud2m, PointCloud4m, PointCloud8m,
     Range, NavSatFix, RadarDetection, RadarTrack>;
 
 /// Returns a vector of supported topic names.
 inline std::vector<std::string> supported_topic_names()
 {
   std::vector<std::string> result;
-  boost::mpl::for_each<TopicTypeList>([&result](auto topic) {
+  performance_test::for_each(TopicTypeList(), [&result](auto topic) {
       using T = decltype(topic);
       result.push_back(T::topic_name());
     });

--- a/performance_test/src/experiment_configuration/topics.hpp
+++ b/performance_test/src/experiment_configuration/topics.hpp
@@ -1124,7 +1124,7 @@ inline std::vector<std::string> supported_topic_names()
 {
   std::vector<std::string> result;
   performance_test::for_each(TopicTypeList(), [&result](const auto & topic) {
-      using T = std::remove_reference_t<std::remove_cv_t<decltype(topic)>>;
+      using T = std::remove_cv_t<std::remove_reference_t<decltype(topic)>>;
       result.push_back(T::topic_name());
     });
   return result;

--- a/performance_test/src/experiment_configuration/topics.hpp
+++ b/performance_test/src/experiment_configuration/topics.hpp
@@ -1123,8 +1123,8 @@ using TopicTypeList = std::tuple<Array1k, Array4k, Array16k, Array32k, Array60k,
 inline std::vector<std::string> supported_topic_names()
 {
   std::vector<std::string> result;
-  performance_test::for_each(TopicTypeList(), [&result](auto topic) {
-      using T = decltype(topic);
+  performance_test::for_each(TopicTypeList(), [&result](const auto & topic) {
+      using T = std::remove_reference_t<std::remove_cv_t<decltype(topic)>>;
       result.push_back(T::topic_name());
     });
   return result;

--- a/performance_test/src/idlgen/Array4m_.idl
+++ b/performance_test/src/idlgen/Array4m_.idl
@@ -13,7 +13,7 @@ module msg
 module dds_
 {
 
-
+#pragma DCPS_DATA_TYPE "performance_test_msgs::msg::dds_::Array4m_"
 
 typedef octet performance_test_msgs__Array4m__octet_array_4194304[4194304];
 

--- a/performance_test/src/idlgen/Array8m_.idl
+++ b/performance_test/src/idlgen/Array8m_.idl
@@ -13,7 +13,7 @@ module msg
 module dds_
 {
 
-
+#pragma DCPS_DATA_TYPE "performance_test_msgs::msg::dds_::Array8m_"
 
 typedef octet performance_test_msgs__Array8m__octet_array_8388608[8388608];
 

--- a/performance_test/src/idlgen/Array8m_.idl
+++ b/performance_test/src/idlgen/Array8m_.idl
@@ -1,0 +1,36 @@
+// generated from rosidl_generator_dds_idl/resource/msg.idl.em
+
+#ifndef __performance_test_msgs__msg__Array8m__idl__
+#define __performance_test_msgs__msg__Array8m__idl__
+
+
+module performance_test_msgs
+{
+
+module msg
+{
+
+module dds_
+{
+
+
+
+typedef octet performance_test_msgs__Array8m__octet_array_4194304[4194304];
+
+struct Array8m_
+{
+
+performance_test_msgs__Array8m__octet_array_4194304 array_;
+  long long time_;
+  unsigned long long id_;
+
+};  // struct Array8m_
+
+
+};  // module dds_
+
+};  // module msg
+
+};  // module performance_test_msgs
+
+#endif  // __performance_test_msgs__msg__Array8m__idl__

--- a/performance_test/src/idlgen/Array8m_.idl
+++ b/performance_test/src/idlgen/Array8m_.idl
@@ -15,12 +15,12 @@ module dds_
 
 
 
-typedef octet performance_test_msgs__Array8m__octet_array_4194304[4194304];
+typedef octet performance_test_msgs__Array8m__octet_array_8388608[8388608];
 
 struct Array8m_
 {
 
-performance_test_msgs__Array8m__octet_array_4194304 array_;
+performance_test_msgs__Array8m__octet_array_8388608 array_;
   long long time_;
   unsigned long long id_;
 

--- a/performance_test/src/idlgen/PointCloud8m_.idl
+++ b/performance_test/src/idlgen/PointCloud8m_.idl
@@ -15,7 +15,7 @@ module msg
 module dds_
 {
 
-
+#pragma DCPS_DATA_TYPE "performance_test_msgs::msg::dds_::PointCloud8m_"
 
 typedef sensor_msgs::msg::dds_::PointField_ performance_test_msgs__PointCloud8m__sensor_msgs__msg__dds___PointField__array_8[8];
 typedef octet performance_test_msgs__PointCloud8m__octet_array_8388608[8388608];

--- a/performance_test/src/idlgen/cyclonedds/CMakeLists.txt
+++ b/performance_test/src/idlgen/cyclonedds/CMakeLists.txt
@@ -37,6 +37,7 @@ set(IDL_SOURCE_C
   ../Array1m_.idl
   ../Array2m_.idl
   ../Array4m_.idl
+  ../Array8m_.idl
 
   ../Struct16_.idl
   ../Struct256_.idl
@@ -47,6 +48,7 @@ set(IDL_SOURCE_C
   ../PointCloud1m_.idl
   ../PointCloud2m_.idl
   ../PointCloud4m_.idl
+  ../PointCloud8m_.idl
 
   ../Range_.idl
   ../NavSatFix_.idl

--- a/performance_test/src/idlgen/fast_rtps/CMakeLists.txt
+++ b/performance_test/src/idlgen/fast_rtps/CMakeLists.txt
@@ -33,6 +33,7 @@ set(IDL_SOURCE_C
     Array1m_.idl
     Array2m_.idl
     Array4m_.idl
+    Array8m_.idl
 
     Struct16_.idl
     Struct256_.idl
@@ -43,6 +44,7 @@ set(IDL_SOURCE_C
     PointCloud1m_.idl
     PointCloud2m_.idl
     PointCloud4m_.idl
+    PointCloud8m_.idl
 
     Range_.idl
     NavSatFix_.idl

--- a/performance_test/src/idlgen/opendds/CMakeLists.txt
+++ b/performance_test/src/idlgen/opendds/CMakeLists.txt
@@ -31,6 +31,8 @@ set(IDL_SOURCE_C
   ../Array60k_.idl
   ../Array1m_.idl
   ../Array2m_.idl
+  ../Array4m_.idl
+  ../Array8m_.idl
   ../Struct16_.idl
   ../Struct256_.idl
   ../Struct4k_.idl
@@ -42,6 +44,7 @@ set(IDL_SOURCE_C
   ../PointCloud1m_.idl
   ../PointCloud2m_.idl
   ../PointCloud4m_.idl
+  ../PointCloud8m_.idl
   ../Range_.idl
   ../NavSatStatus_.idl
   ../Point_.idl

--- a/performance_test/src/msg/Array8m.msg
+++ b/performance_test/src/msg/Array8m.msg
@@ -1,3 +1,3 @@
-byte[4194304] array
+byte[8388608] array
 int64 time
 uint64 id


### PR DESCRIPTION
Adds:
- Array4m (which was partially added before)
- Array8m
- PointCloud8m (partially added before)

`boost::mpl::list` is surprisingly limited to 20 types, so I replaced it with a `std::tuple` and custom template magic.