### PR TITLE
Delete python3-pip from requirements.in

### DIFF
--- a/performance_test/helper_scripts/apex_performance_plotter/requirements.in
+++ b/performance_test/helper_scripts/apex_performance_plotter/requirements.in
@@ -2,4 +2,3 @@ Click
 Jinja2
 pandas
 matplotlib
-python3-pip


### PR DESCRIPTION
When I do:

```
pip3 install performance_test/helper_scripts/apex_performance_plotter
```

in Focal, I get a message saying that the requirement can't be satisfied.
Deleting it from the list solved the problem.