### PR TITLE
Avoid stack overflow when using large messages

### DIFF
--- a/performance_test/src/communication_abstractions/ros2_communicator.hpp
+++ b/performance_test/src/communication_abstractions/ros2_communicator.hpp
@@ -88,7 +88,8 @@ public:
   explicit ROS2Communicator(SpinLock & lock)
   : Communicator(lock),
     m_node(ResourceManager::get().ros2_node()),
-    m_ROS2QOSAdapter(ROS2QOSAdapter(m_ec.qos()).get()) {}
+    m_ROS2QOSAdapter(ROS2QOSAdapter(m_ec.qos()).get()),
+    m_data_copy(std::make_unique<DataType>()) {}
 
   /**
    * \brief Publishes the provided data.
@@ -134,8 +135,8 @@ public:
  */
   void publish(const DataType & data, const std::chrono::nanoseconds time)
   {
-    DataType copy = data;
-    publish(copy, time);
+    *m_data_copy = data;
+    publish(*m_data_copy, time);
   }
 
   /// Reads received data from ROS 2 using callbacks
@@ -189,6 +190,7 @@ protected:
 
 private:
   std::shared_ptr<::rclcpp::Publisher<DataType>> m_publisher;
+  std::unique_ptr<DataType> m_data_copy;
 };
 }  // namespace performance_test
 #endif  // COMMUNICATION_ABSTRACTIONS__ROS2_COMMUNICATOR_HPP_

--- a/performance_test/src/data_running/data_runner.hpp
+++ b/performance_test/src/data_running/data_runner.hpp
@@ -131,7 +131,7 @@ private:
   /// The function running inside the thread doing all the work.
   void thread_function()
   {
-    typename TCommunicator::DataType data;
+    auto data = std::make_unique<typename TCommunicator::DataType>();
 
     auto next_run = std::chrono::steady_clock::now() +
       std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -147,7 +147,7 @@ private:
       {
         std::chrono::nanoseconds epoc_time =
           std::chrono::steady_clock::now().time_since_epoch();
-        m_com.publish(data, epoc_time);
+        m_com.publish(*data, epoc_time);
       }
       if (m_run_type == RunType::SUBSCRIBER) {
         m_com.update_subscription();

--- a/performance_test/src/data_running/data_runner.hpp
+++ b/performance_test/src/data_running/data_runner.hpp
@@ -20,6 +20,7 @@
 #include <osrf_testing_tools_cpp/memory_tools/memory_tools.hpp>
 #endif
 #include <atomic>
+#include <memory>
 #include <thread>
 
 #include "../utilities/spin_lock.hpp"


### PR DESCRIPTION
When trying to run locally the performance test using the new messages (`Array8m`, `PointCloud8m`), I was experiencing a weird SEGFAULT that didn't happen if using other msgs (e.g. `Array4m`).

After a while, I realized that we're allocating the msgs in the stack, and it was overflowing (default stack size in Ubuntu is 8MB).

This PR modifies the communicator to allocate messages in the heap instead of the stack, thus avoiding the overflow.
The allocation happens just once at startup, so it shouldn't influence any of the measurements.