### PR TITLE
Support FastDDS 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Introduction
 
-**Version Support:** ROS2 Dashing, Fast-RTPS 1.8.0
+**Version Support:** ROS2 Dashing, Fast-DDS 2.0.x
 
 This test allows you to test performance and latency of various communication means
 like ROS 2, ROS 2 Waitset, FastRTPS, Connext DDS Micro and Eclipse Cyclone DDS.

--- a/performance_test/src/communication_abstractions/fast_rtps_communicator.hpp
+++ b/performance_test/src/communication_abstractions/fast_rtps_communicator.hpp
@@ -26,7 +26,6 @@
 #include <fastrtps/publisher/Publisher.h>
 #include <fastrtps/subscriber/SampleInfo.h>
 #include <fastrtps/Domain.h>
-#include <fastrtps/utils/eClock.h>
 
 #include <atomic>
 


### PR DESCRIPTION
Cherry-picks https://github.com/ros2/performance_test/pull/20 to the correct branch.

This is the only fix needed, the [other fix](https://github.com/ros2/performance_test/pull/20#discussion_r441517664) was already done in https://github.com/ros2/performance_test/pull/9.