### PR TITLE
Fix Fast-RTPS build.

### DIFF
--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -64,9 +64,7 @@ endif()
 ament_export_include_directories(include)
 ament_export_dependencies(rosidl_default_runtime)
 
-# This is a workaround for broken include paths on some systems.
-include_directories(${FastRTPS_INCLUDE_DIR} ${FastRTPS_INCLUDE_DIR}/fastrtps/include ${fastcdr_INCLUDE_DIR})
-include_directories(include ${osrf_testing_tools_cpp_INCLUDE_DIR})
+include_directories(include)
 
 # FastRTPS
 option(PERFORMANCE_TEST_FASTRTPS_ENABLED "Enable FastRTPS" OFF)
@@ -316,7 +314,7 @@ endif()
 
 if(PERFORMANCE_TEST_FASTRTPS_ENABLED)
   target_link_libraries(${EXE_NAME}
-      ${FastRTPS_LIBRARIES}
+      fastrtps
       fast_rtps_idl
       fastcdr)
 endif()

--- a/performance_test/package.xml
+++ b/performance_test/package.xml
@@ -13,6 +13,7 @@
 
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>boost</build_depend>
+  <build_depend>fastrtps</build_depend>
   <build_depend>fastrtps_cmake_module</build_depend>
   <build_depend>java</build_depend>
   <build_depend>maven</build_depend>


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix #29.  A CI run with this in place is at https://build.ros2.org/view/Queue/job/Rci__nightly-performance_ubuntu_focal_amd64/287