### PR TITLE
Fix build on windows

### DIFF
--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -399,6 +399,10 @@ if(TARGET rti_connextdds_idl)
   )
 endif()
 
+target_include_directories(${EXE_NAME}
+  PRIVATE
+    ${Boost_INCLUDE_DIRS}
+)
 target_link_libraries(${EXE_NAME}
     ${Boost_LIBRARIES}
     ${OPTIONAL_LIBRARIES}

--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(OPTIONAL_LIBRARIES)
 
 # Default to C++14
 set(CMAKE_CXX_STANDARD 14)
+set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost COMPONENTS program_options timer REQUIRED)
 find_package(ament_cmake REQUIRED)
 

--- a/performance_test/compile_options.cmake
+++ b/performance_test/compile_options.cmake
@@ -21,6 +21,7 @@ function(set_compile_options target)
         add_definitions(-D_CRT_NONSTDC_NO_WARNINGS)
         add_definitions(-D_CRT_SECURE_NO_WARNINGS)
         add_definitions(-D_WINSOCK_DEPRECATED_NO_WARNINGS)
+        add_definitions(/bigobj)
     else()
         target_compile_options(${target} PRIVATE  -Wall
                 -Wextra

--- a/performance_test/src/communication_abstractions/ros2_communicator.hpp
+++ b/performance_test/src/communication_abstractions/ros2_communicator.hpp
@@ -124,13 +124,13 @@ public:
       unlock();
       m_publisher->publish(std::move(borrowed_message));
     } else {
-      DataType data;
+      // DataType data;
       lock();
-      data.time = time;
-      data.id = next_sample_id();
+      m_data_copy->time = time;
+      m_data_copy->id = next_sample_id();
       increment_sent();  // We increment before publishing so we don't have to lock twice.
       unlock();
-      m_publisher->publish(data);
+      m_publisher->publish(*m_data_copy);
     }
   }
 

--- a/performance_test/src/experiment_execution/analysis_result.cpp
+++ b/performance_test/src/experiment_execution/analysis_result.cpp
@@ -14,7 +14,9 @@
 
 #include "analysis_result.hpp"
 
-#include <sys/times.h>
+#if !defined(WIN32)
+  #include <sys/times.h>
+#endif  // !defined(WIN32)
 
 #include <iomanip>
 #include <string>
@@ -25,10 +27,12 @@
 namespace performance_test
 {
 
+#if !defined(WIN32)
 std::ostream & operator<<(std::ostream & stream, const timeval & e)
 {
   return stream << double(e.tv_sec) + double(e.tv_usec) / 1000000.0;
 }
+#endif  // !defined(WIN32)
 
 AnalysisResult::AnalysisResult(
   const std::chrono::nanoseconds experiment_start,
@@ -53,6 +57,7 @@ AnalysisResult::AnalysisResult(
   m_sub_loop_time_reserve(sub_loop_time_reserve),
   m_cpu_info(cpu_info)
 {
+#if !defined(WIN32)
   const auto ret = getrusage(RUSAGE_SELF, &m_sys_usage);
 #if defined(QNX)
   // QNX getrusage() max_rss does not give the correct value. Using a different method to get
@@ -66,6 +71,7 @@ AnalysisResult::AnalysisResult(
   if (ret != 0) {
     throw std::runtime_error("Could not get system resource usage.");
   }
+#endif  // !defined(WIN32)
   if (m_num_samples_received != static_cast<uint64_t>(m_latency.n())) {
     // TODO(andreas.pasternak): Commented out flaky assertion. Need to check if it actually a bug.
     /*throw std::runtime_error("Statistics result sample size does not match: "
@@ -170,6 +176,24 @@ std::string AnalysisResult::to_csv_string(const bool pretty_print, std::string s
    * output below
    */
 
+#if defined(WIN32)
+  ss << 0 /* m_sys_usage.ru_utime */ << st;
+  ss << 0 /* m_sys_usage.ru_stime */ << st;
+  ss << 0 /* m_sys_usage.ru_maxrss */ << st;
+  ss << 0 /* m_sys_usage.ru_ixrss */ << st;
+  ss << 0 /* m_sys_usage.ru_idrss */ << st;
+  ss << 0 /* m_sys_usage.ru_isrss */ << st;
+  ss << 0 /* m_sys_usage.ru_minflt */ << st;
+  ss << 0 /* m_sys_usage.ru_majflt */ << st;
+  ss << 0 /* m_sys_usage.ru_nswap */ << st;
+  ss << 0 /* m_sys_usage.ru_inblock */ << st;
+  ss << 0 /* m_sys_usage.ru_oublock */ << st;
+  ss << 0 /* m_sys_usage.ru_msgsnd */ << st;
+  ss << 0 /* m_sys_usage.ru_msgrcv */ << st;
+  ss << 0 /* m_sys_usage.ru_nsignals */ << st;
+  ss << 0 /* m_sys_usage.ru_nvcsw */ << st;
+  ss << 0 /* m_sys_usage.ru_nivcsw */ << st;
+#else
   ss << m_sys_usage.ru_utime << st;
   ss << m_sys_usage.ru_stime << st;
   ss << m_sys_usage.ru_maxrss << st;
@@ -186,6 +210,7 @@ std::string AnalysisResult::to_csv_string(const bool pretty_print, std::string s
   ss << m_sys_usage.ru_nsignals << st;
   ss << m_sys_usage.ru_nvcsw << st;
   ss << m_sys_usage.ru_nivcsw << st;
+#endif
 
   ss << m_cpu_info.cpu_usage() << st;
 

--- a/performance_test/src/experiment_execution/analysis_result.hpp
+++ b/performance_test/src/experiment_execution/analysis_result.hpp
@@ -15,8 +15,10 @@
 #ifndef EXPERIMENT_EXECUTION__ANALYSIS_RESULT_HPP_
 #define EXPERIMENT_EXECUTION__ANALYSIS_RESULT_HPP_
 
-#include <sys/time.h>
-#include <sys/resource.h>
+#if !defined(WIN32)
+  #include <sys/time.h>
+  #include <sys/resource.h>
+#endif  // !defined(WIN32)
 
 #include <chrono>
 #include <sstream>
@@ -33,8 +35,10 @@
 namespace performance_test
 {
 
+#if !defined(WIN32)
 /// Outstream operator for timeval to seconds (double).
 std::ostream & operator<<(std::ostream & stream, const timeval & e);
+#endif  // !defined(WIN32)
 #ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
 class RusageTracker
 {
@@ -297,7 +301,9 @@ private:
   RusageTracker m_sys_tracker;
 #pragma db transient
 #endif
+#if !defined(WIN32)
   rusage m_sys_usage;
+#endif  // !defined(WIN32)
   const CpuInfo m_cpu_info;
 };
 

--- a/performance_test/src/experiment_execution/analyze_runner.cpp
+++ b/performance_test/src/experiment_execution/analyze_runner.cpp
@@ -147,7 +147,7 @@ void AnalyzeRunner::run()
   while (!check_exit(experiment_start)) {
     const auto loop_start = std::chrono::steady_clock::now();
 
-    sleep(1);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
 
     std::for_each(m_pub_runners.begin(), m_pub_runners.end(), [](auto & a) {a->sync_reset();});
     std::for_each(m_sub_runners.begin(), m_sub_runners.end(), [](auto & a) {a->sync_reset();});


### PR DESCRIPTION
This should be considered as a starting point towards fully supporting performance tests to be run on Windows.

* Commits bea0040 and 141987e solve some issues with boost libraries.
* Commit 17b7283 removes support for resource usage on Windows, as `getrusage` and `sys/times.h` are not present there
* Commit 6410b80 changes a `sleep()` into a `std::this_thread::sleep_for()`
* Commit 1e8b378 tells compiler to create big objects with `/bigobj`
* Commit 81995bc avoids some stack overflows by using a class member data object instead of a local variable