### PR TITLE
Fix a warning on rolling.

### DIFF
--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -278,14 +278,15 @@ execute_process(
 )
 add_definitions(-DPERFORMANCE_TEST_VERSION="${PERF_TEST_VERSION}")
 
-rosidl_target_interfaces(${EXE_NAME} ${PROJECT_NAME} "rosidl_typesupport_cpp")
+rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
 
 ament_target_dependencies(${EXE_NAME}
     "rclcpp" ${OPTIONAL_AMENT_DEPENDENCES})
 
 target_link_libraries(${EXE_NAME}
     ${Boost_LIBRARIES}
-    ${OPTIONAL_LIBRARIES})
+    ${OPTIONAL_LIBRARIES}
+    ${cpp_typesupport_target})
 
 if(PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED)
   foreach(header ${${PROJECT_NAME}_HEADERS})


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that this will *not* work on earlier versions (like Galactic), so we'll probably have to branch off for that (like we did for Foxy in https://github.com/ros2/buildfarm_perf_tests/pull/99 and https://github.com/ros2/ros_buildfarm_config/pull/153).