### PR TITLE
Drop some unused test dependencies

### DIFF
--- a/performance_test/package.xml
+++ b/performance_test/package.xml
@@ -30,14 +30,9 @@
   <exec_depend>rmw_implementation</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
-  <test_depend>ament_cmake_nose</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>launch</test_depend>
-  <test_depend>launch_testing</test_depend>
-  <test_depend>rmw_implementation_cmake</test_depend>
-  <test_depend>test_osrf_testing_tools_cpp</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 


### PR DESCRIPTION
These changes were made upstream in [ApexAI/performance_test#307](https://gitlab.com/ApexAI/performance_test/-/merge_requests/307) and [ApexAI/performance_test#373](https://gitlab.com/ApexAI/performance_test/-/merge_requests/373).

[![Build Status](https://build.ros2.org/buildStatus/icon?job=Rci__overlay_ubuntu_jammy_amd64&build=17)](https://build.ros2.org/view/Rci/job/Rci__overlay_ubuntu_jammy_amd64/17/)