### PR TITLE
Pass `-cdr v2` to Fast DDS Gen

### DIFF
--- a/performance_test/bin/fastrtpsgen
+++ b/performance_test/bin/fastrtpsgen
@@ -11,4 +11,4 @@ if [ $? != 0 ]; then
     java_exec="${JAVA_HOME}/bin/java"
 fi
 
-exec $java_exec -jar "$dir/fastrtpsgen.jar" -cdr v1 "$@"
+exec $java_exec -jar "$dir/fastrtpsgen.jar" -cdr v2 "$@"


### PR DESCRIPTION
This should fix #43 by telling Fast DDS Gen to generate code for Fast CDR v2