### PR TITLE
Fix the build on Noble

### DIFF
--- a/performance_test/src/data_running/data_runner.hpp
+++ b/performance_test/src/data_running/data_runner.hpp
@@ -210,9 +210,9 @@ private:
     m_memory_tools_on = true;
     #endif
   }
+  SpinLock m_lock;
   TCommunicator m_com;
   std::atomic<bool> m_run;
-  SpinLock m_lock;
 
   uint64_t m_sum_received_samples;
   uint64_t m_sum_lost_samples;

--- a/performance_test/src/experiment_configuration/qos_abstraction.hpp
+++ b/performance_test/src/experiment_configuration/qos_abstraction.hpp
@@ -15,6 +15,7 @@
 #ifndef EXPERIMENT_CONFIGURATION__QOS_ABSTRACTION_HPP_
 #define EXPERIMENT_CONFIGURATION__QOS_ABSTRACTION_HPP_
 
+#include <cstdint>
 #include <ostream>
 
 namespace performance_test


### PR DESCRIPTION
There are 3 fixes in here:

1.  Make sure to `#include <cstdint>` as necessary.
2.  Switch to using `rosidl_get_typesupport_target`, which is our modern way of doing things.
3.  Make sure to move lock initialization before m_com initialization to resolve a warning.

This should fix #46 