### PR TITLE
Fix cpplint build/include_order errors

### DIFF
--- a/performance_test/src/communication_abstractions/connext_dds_micro_communicator.hpp
+++ b/performance_test/src/communication_abstractions/connext_dds_micro_communicator.hpp
@@ -292,7 +292,8 @@ private:
   * \param data The data to publish.
   */
   template<typename T>
-  static auto init_data(T & data)->decltype (data.header_.frame_id_, void ()) {
+  static auto init_data(T & data)->decltype (data.header_.frame_id_, void ())
+  {
     data.header_.frame_id_ = DDS_String_dup("frame_id");
     init_fields(data);
   }
@@ -314,7 +315,8 @@ private:
   * \param data The data to publish.
   */
   template<typename T>
-  static auto init_fields(T & data)->decltype (data.fields_, void ()) {
+  static auto init_fields(T & data)->decltype (data.fields_, void ())
+  {
     auto fields_size = size(data.fields_);
     for (uint8_t i = 0; i < fields_size; i++) {
       data.fields_[i].name_ = DDS_String_dup("name");

--- a/performance_test/src/communication_abstractions/resource_manager.hpp
+++ b/performance_test/src/communication_abstractions/resource_manager.hpp
@@ -15,6 +15,10 @@
 #ifndef COMMUNICATION_ABSTRACTIONS__RESOURCE_MANAGER_HPP_
 #define COMMUNICATION_ABSTRACTIONS__RESOURCE_MANAGER_HPP_
 
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+
 #ifdef PERFORMANCE_TEST_FASTRTPS_ENABLED
   #include <fastrtps/participant/Participant.h>
   #include <fastrtps/attributes/ParticipantAttributes.h>
@@ -45,9 +49,6 @@
 #endif
 
 #include <rclcpp/rclcpp.hpp>
-#include <cstdlib>
-#include <memory>
-#include <mutex>
 
 #include "../experiment_configuration/experiment_configuration.hpp"
 

--- a/performance_test/src/communication_abstractions/ros2_callback_communicator.hpp
+++ b/performance_test/src/communication_abstractions/ros2_callback_communicator.hpp
@@ -15,10 +15,10 @@
 #ifndef COMMUNICATION_ABSTRACTIONS__ROS2_CALLBACK_COMMUNICATOR_HPP_
 #define COMMUNICATION_ABSTRACTIONS__ROS2_CALLBACK_COMMUNICATOR_HPP_
 
-#include <rclcpp/rclcpp.hpp>
-
 #include <memory>
 #include <atomic>
+
+#include <rclcpp/rclcpp.hpp>
 
 #include "../experiment_configuration/topics.hpp"
 

--- a/performance_test/src/communication_abstractions/ros2_communicator.hpp
+++ b/performance_test/src/communication_abstractions/ros2_communicator.hpp
@@ -15,11 +15,10 @@
 #ifndef COMMUNICATION_ABSTRACTIONS__ROS2_COMMUNICATOR_HPP_
 #define COMMUNICATION_ABSTRACTIONS__ROS2_COMMUNICATOR_HPP_
 
-
-#include <rclcpp/rclcpp.hpp>
-
 #include <memory>
 #include <atomic>
+
+#include <rclcpp/rclcpp.hpp>
 
 #include "../experiment_configuration/topics.hpp"
 #include "../experiment_configuration/qos_abstraction.hpp"

--- a/performance_test/src/communication_abstractions/ros2_waitset_communicator.hpp
+++ b/performance_test/src/communication_abstractions/ros2_waitset_communicator.hpp
@@ -15,12 +15,12 @@
 #ifndef COMMUNICATION_ABSTRACTIONS__ROS2_WAITSET_COMMUNICATOR_HPP_
 #define COMMUNICATION_ABSTRACTIONS__ROS2_WAITSET_COMMUNICATOR_HPP_
 
-#include <rclcpp/rclcpp.hpp>
-
 #include <atomic>
 #include <memory>
 #include <mutex>
 #include <thread>
+
+#include <rclcpp/rclcpp.hpp>
 
 #include "../experiment_configuration/topics.hpp"
 #include "../experiment_configuration/qos_abstraction.hpp"

--- a/performance_test/src/data_running/data_runner_base.hpp
+++ b/performance_test/src/data_running/data_runner_base.hpp
@@ -15,8 +15,9 @@
 #ifndef DATA_RUNNING__DATA_RUNNER_BASE_HPP_
 #define DATA_RUNNING__DATA_RUNNER_BASE_HPP_
 
-#include <boost/core/noncopyable.hpp>
 #include <string>
+
+#include <boost/core/noncopyable.hpp>
 
 #ifdef PERFORMANCE_TEST_MEMORYTOOLS_ENABLED
 #include <osrf_testing_tools_cpp/memory_tools/memory_tools.hpp>

--- a/performance_test/src/data_running/data_runner_factory.cpp
+++ b/performance_test/src/data_running/data_runner_factory.cpp
@@ -14,10 +14,10 @@
 
 #include "data_runner_factory.hpp"
 
-#include <performance_test/for_each.hpp>
-
 #include <string>
 #include <memory>
+
+#include <performance_test/for_each.hpp>
 
 #ifdef PERFORMANCE_TEST_CALLBACK_EXECUTOR_ENABLED
   #include "../communication_abstractions/ros2_callback_communicator.hpp"

--- a/performance_test/src/experiment_configuration/experiment_configuration.cpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.cpp
@@ -14,13 +14,13 @@
 
 #include "experiment_configuration.hpp"
 
-#include <boost/program_options.hpp>
 #include <rmw/rmw.h>
-
-#include <iostream>
-#include <iomanip>
-#include <exception>
 #include <string>
+#include <exception>
+#include <iomanip>
+#include <iostream>
+
+#include <boost/program_options.hpp>
 
 #include "topics.hpp"
 

--- a/performance_test/src/experiment_configuration/experiment_configuration.hpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.hpp
@@ -15,13 +15,15 @@
 #ifndef EXPERIMENT_CONFIGURATION__EXPERIMENT_CONFIGURATION_HPP_
 #define EXPERIMENT_CONFIGURATION__EXPERIMENT_CONFIGURATION_HPP_
 
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
-
 #include <string>
 #include <fstream>
 #include <vector>
 #include <memory>
+#include <chrono>
+
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
 
 #include "qos_abstraction.hpp"
 #include "communication_mean.hpp"
@@ -33,7 +35,6 @@
 #ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
   #include <odb/core.hxx>
 #endif
-#include <chrono>
 
 namespace performance_test
 {

--- a/performance_test/src/experiment_configuration/external_info_storage.hpp
+++ b/performance_test/src/experiment_configuration/external_info_storage.hpp
@@ -15,11 +15,12 @@
 #ifndef EXPERIMENT_CONFIGURATION__EXTERNAL_INFO_STORAGE_HPP_
 #define EXPERIMENT_CONFIGURATION__EXTERNAL_INFO_STORAGE_HPP_
 
+#include <iostream>
+#include <string>
+
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/exceptions.hpp>
-#include <iostream>
-#include <string>
 
 #ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
   #include <odb/core.hxx>

--- a/performance_test/src/experiment_execution/analyze_runner.cpp
+++ b/performance_test/src/experiment_execution/analyze_runner.cpp
@@ -15,14 +15,11 @@
 #include <cstdlib>
 #include <cstddef>
 #include <iostream>
+#include <exception>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
-
-#ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
-  #include <exception>
-  #include <memory>
-#endif
 
 #include <boost/algorithm/string.hpp>
 

--- a/performance_test/src/experiment_execution/analyze_runner.cpp
+++ b/performance_test/src/experiment_execution/analyze_runner.cpp
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <boost/algorithm/string.hpp>
 #include <algorithm>
 #include <cstdlib>
 #include <cstddef>
@@ -20,14 +19,19 @@
 #include <string>
 #include <vector>
 
+#ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
+  #include <exception>
+  #include <memory>
+#endif
+
+#include <boost/algorithm/string.hpp>
+
 #include "analyze_runner.hpp"
 
 #include "analysis_result.hpp"
 
 #ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
   #include <odb/database.hxx>
-  #include <exception>
-  #include <memory>
   #ifdef DATABASE_SQLITE
     #include <odb/sqlite/database.hxx>
   #endif

--- a/performance_test/src/utilities/cpu_usage_tracker.hpp
+++ b/performance_test/src/utilities/cpu_usage_tracker.hpp
@@ -15,8 +15,10 @@
 #ifndef UTILITIES__CPU_USAGE_TRACKER_HPP_
 #define UTILITIES__CPU_USAGE_TRACKER_HPP_
 
-#include <boost/timer/timer.hpp>
 #include <thread>
+
+#include <boost/timer/timer.hpp>
+
 
 #if defined(QNX)
 #include <sys/neutrino.h>

--- a/performance_test_ros1_publisher/include/performance_test_ros1_publisher/msg_types.hpp
+++ b/performance_test_ros1_publisher/include/performance_test_ros1_publisher/msg_types.hpp
@@ -1,10 +1,10 @@
 #ifndef PERFORMANCE_TEST_ROS1_PUBLISHER_MSG_TYPES_HPP_INCLUDED
 #define PERFORMANCE_TEST_ROS1_PUBLISHER_MSG_TYPES_HPP_INCLUDED
 
-#include <boost/mpl/list.hpp>
-
 #include <chrono>
 #include <memory>
+
+#include <boost/mpl/list.hpp>
 
 #include "performance_test_ros1_msgs/Array16k.h"
 #include "performance_test_ros1_msgs/Array1k.h"

--- a/performance_test_ros1_publisher/src/publisher.cpp
+++ b/performance_test_ros1_publisher/src/publisher.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "ros/ros.h"
 
 #include "performance_test_ros1_publisher/msg_types.hpp"
@@ -6,7 +8,7 @@
 #include <boost/mpl/for_each.hpp>
 #include <boost/program_options.hpp>
 
-#include <memory>
+
 
 std::shared_ptr<MsgBase> msg_publisher_factory(ros::NodeHandle& nh, std::string topic_name)
 {


### PR DESCRIPTION
Attempt to address linter warnings on: https://build.ros2.org/view/Rci/job/Rci__nightly-performance_ubuntu_noble_amd64/61/consoleFull#console-section-43

@Crola1702 Can you run CI on this one to verify? :pray: You can use this job that Chris launched as reference: https://github.com/ros2/performance_test/pull/38#issuecomment-1949365922 