### PR TITLE
Change log message to STATUS

### DIFF
--- a/performance_test/src/idlgen/fast_rtps/CMakeLists.txt
+++ b/performance_test/src/idlgen/fast_rtps/CMakeLists.txt
@@ -67,7 +67,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/objs/${RTIME_TARG
 
 find_program(FASTRTPS_BIN "fastrtpsgen")
 if(NOT FASTRTPS_BIN)
-  message(WARNING "Could not find program 'fastrtpsgen' in path. Trying to use bundled version")
+  message(STATUS "Could not find program 'fastrtpsgen' in path. Trying to use bundled version")
   find_program(FASTRTPS_BIN "fastrtpsgen" PATHS "${PROJECT_SOURCE_DIR}/bin")
   if(NOT FASTRTPS_BIN)
     message(FATAL_ERROR "Could not find program 'fastrtpsgen'")


### PR DESCRIPTION
Small change to status message. Build has been using the bundled `fastrtpsgen`, so the job shouldn't generate a warning about it.

Reference conversation: https://osrf.slack.com/archives/C04R65U5CNA/p1721769869944609
CMake warnings to be fixed after this is merged: https://build.ros2.org/view/Rci/job/Rci__nightly-performance_ubuntu_noble_amd64/68/cmake/