### PR TITLE
Use rosidl_get_typesupport_target instead of rosidl_target_interfaces

### DIFF
--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -277,14 +277,15 @@ execute_process(
 )
 add_definitions(-DPERFORMANCE_TEST_VERSION="${PERF_TEST_VERSION}")
 
-rosidl_target_interfaces(${EXE_NAME} ${PROJECT_NAME} "rosidl_typesupport_cpp")
+rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
 
 ament_target_dependencies(${EXE_NAME}
     "rclcpp" ${OPTIONAL_AMENT_DEPENDENCES})
 
 target_link_libraries(${EXE_NAME}
     ${Boost_LIBRARIES}
-    ${OPTIONAL_LIBRARIES})
+    ${OPTIONAL_LIBRARIES}
+    "${cpp_typesupport_target}")
 
 if(PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED)
   foreach(header ${${PROJECT_NAME}_HEADERS})


### PR DESCRIPTION
As the title says, should fix remaining warnings in the iron performance jobs. Same as #57.

This one will have to be merged in order to fix -wsign-order warnings: https://github.com/ros2/ros2/pull/1595



