### PR TITLE
Fix: ament_target_dependencies() is deprecated

### DIFF
--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -278,8 +278,10 @@ add_definitions(-DPERFORMANCE_TEST_VERSION="${PERF_TEST_VERSION}")
 
 rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
 
-ament_target_dependencies(${EXE_NAME}
-    "rclcpp" ${OPTIONAL_AMENT_DEPENDENCES})
+target_link_libraries(${EXE_NAME} PUBLIC
+  rclcpp::rclcpp
+  ${OPTIONAL_AMENT_DEPENDENCES}
+)
 
 target_link_libraries(${EXE_NAME}
     ${Boost_LIBRARIES}


### PR DESCRIPTION
## Description

Buildfarm https://build.ros2.org/job/Rci__nightly-performance_ubuntu_noble_amd64/ have a CMake Warning that says

```
ament_target_dependencies() is deprecated. Use target_link_libraries()
```
so I changed in `performance_test/CMakeLists.txt`:

```diff
- ament_target_dependencies(${EXE_NAME}
-     "rclcpp" ${OPTIONAL_AMENT_DEPENDENCES})

+ target_link_libraries(${EXE_NAME} PUBLIC
+   rclcpp::rclcpp
+   ${OPTIONAL_AMENT_DEPENDENCES}
+ )
``` 


### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

CC: @Crola1702 @mjcarroll 