### PR TITLE
Fix: fixed redundant target_link_libraries warning

### DIFF
--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -286,6 +286,8 @@ target_link_libraries(${EXE_NAME} PUBLIC
 target_link_libraries(${EXE_NAME}
     ${Boost_LIBRARIES}
     ${OPTIONAL_LIBRARIES}
+    ${OPTIONAL_AMENT_DEPENDENCES}
+    rclcpp::rclcpp
     "${cpp_typesupport_target}")
 
 if(PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED)

--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -281,7 +281,6 @@ rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_t
 target_link_libraries(${EXE_NAME}
     ${Boost_LIBRARIES}
     ${OPTIONAL_LIBRARIES}
-    ${OPTIONAL_AMENT_DEPENDENCES}
     rclcpp::rclcpp
     "${cpp_typesupport_target}")
 

--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -278,11 +278,6 @@ add_definitions(-DPERFORMANCE_TEST_VERSION="${PERF_TEST_VERSION}")
 
 rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
 
-target_link_libraries(${EXE_NAME} PUBLIC
-  rclcpp::rclcpp
-  ${OPTIONAL_AMENT_DEPENDENCES}
-)
-
 target_link_libraries(${EXE_NAME}
     ${Boost_LIBRARIES}
     ${OPTIONAL_LIBRARIES}


### PR DESCRIPTION
## Description

```diff

- target_link_libraries(${EXE_NAME} PUBLIC
-   rclcpp::rclcpp
-   ${OPTIONAL_AMENT_DEPENDENCES}
- )

target_link_libraries(${EXE_NAME}
    ${Boost_LIBRARIES}
    ${OPTIONAL_LIBRARIES}
+  ${OPTIONAL_AMENT_DEPENDENCES}
+  rclcpp::rclcpp
    "${cpp_typesupport_target}")

```

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No AI used

### Additional Information

Build https://build.ros2.org/job/Rci__nightly-performance_ubuntu_noble_amd64/281 was failing building because in https://github.com/ros2/performance_test/pull/65 I accidentally introduced an error duplicating target_link_libraries but it was already declared with different dependencies

Log output:
```
--- stderr: performance_test
CMake Error at CMakeLists.txt:286 (target_link_libraries):
  The keyword signature for target_link_libraries has already been used with
  the target "perf_test".  All uses of target_link_libraries with a target
  must be either all-keyword or all-plain.

  The uses of the keyword signature are here:

   * CMakeLists.txt:281 (target_link_libraries)
```

CC: @Crola1702