### PR TITLE
fix: add missing <cstdint> in qos_abstraction.hpp

### DIFF
--- a/performance_test/src/experiment_configuration/qos_abstraction.hpp
+++ b/performance_test/src/experiment_configuration/qos_abstraction.hpp
@@ -16,6 +16,7 @@
 #define EXPERIMENT_CONFIGURATION__QOS_ABSTRACTION_HPP_
 
 #include <ostream>
+#include <cstdint>
 
 namespace performance_test
 {


### PR DESCRIPTION
Ran into a build failure on Ubuntu 24.04 with GCC 13 using jazzy - turns out uint32_t wasn't being pulled in transitively anymore. Adding the include explicitly fixes it. Same thing I believe was fixed in rosbag2 (#1383).

## Description

<!--
qos_abstraction.hpp uses uint32_t  but doesn't inculde <cstdint>.
-->
build fails wiht gcc 13 as it doesn't pull in transitively as experienced on ubuntu 24.04


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*

.
-->

Fixes # (issue)
No - just a build fix only

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.

-->
Seems similar issue observed and fixed in rosbag #1383.