### PR TITLE
Changed the rclcpp call in cmakelist

### DIFF
--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -279,7 +279,7 @@ add_definitions(-DPERFORMANCE_TEST_VERSION="${PERF_TEST_VERSION}")
 rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
 
 target_link_libraries(${EXE_NAME}
-    "rclcpp" ${OPTIONAL_AMENT_DEPENDENCES}
+    rclcpp::rclcpp
     ${Boost_LIBRARIES}
     ${OPTIONAL_LIBRARIES}
     "${cpp_typesupport_target}")


### PR DESCRIPTION
## Description

Changed "rclcpp" call to `rclcpp::rclcpp` making this compatible with `target_link_libraries` format.

Fixes #67 

### Additional Information

The change made before inserted an error in `rclcpp` call

```
00:06:43.783 /tmp/ws2/src/performance_test/performance_test/src/main.cpp:15:10: fatal error: rclcpp/rclcpp.hpp: No such file or directory
00:06:43.783    15 | #include <rclcpp/rclcpp.hpp>
00:06:43.783       |          ^~~~~~~~~~~~~~~~~~~
00:06:43.854 compilation terminated.
00:06:44.031 gmake[2]: *** [CMakeFiles/perf_test.dir/build.make:85: CMakeFiles/perf_test.dir/src/main.cpp.o] Error 1
00:06:44.040 gmake[1]: *** [CMakeFiles/Makefile2:682: CMakeFiles/perf_test.dir/all] Error 2
00:06:44.040 gmake: *** [Makefile:146: all] Error 2
00:06:44.045 ---
00:06:44.422 Failed   <<< performance_test [3min 40s, exited with code 2]
```