### PR TITLE
Set default visibility for 'fast_rtps_idl' library

### DIFF
--- a/performance_test/src/idlgen/fast_rtps/CMakeLists.txt
+++ b/performance_test/src/idlgen/fast_rtps/CMakeLists.txt
@@ -106,4 +106,9 @@ endforeach()
 add_library(fast_rtps_idl
     ${IDL_GEN_H_LIST} ${IDL_GEN_C_LIST} ${fastdds_LIBRARIES})
 set_compile_options(fast_rtps_idl)
+set_target_properties(fast_rtps_idl PROPERTIES
+    CXX_VISIBILITY_PRESET default
+    C_VISIBILITY_PRESET default
+    VISIBILITY_INLINES_HIDDEN OFF)
+target_compile_options(fast_rtps_idl PRIVATE -fvisibility=default)
 set(FAST_RTPS_IDL_INCLUDE_DIR ${IDL_GEN_ROOT}/.. PARENT_SCOPE)


### PR DESCRIPTION
## Description

This PR sets default visibility for `fast_rtps_idl` library.
<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #71 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
